### PR TITLE
Improve hit precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Hitmarkers for Garry's Mod
 | custom_hitmarkers_npc_enabled | Enables hitmarkers for NPCs. | 0 |
 | custom_hitmarkers_ent_enabled | Enables hitmarkers for other entities. | 0 |
 | custom_hitmarkers_sound_enabled | Enables hitmarker sounds. | 1 |
-| custom_hitmarkers_round_enabled | Rounds up damage numbers. | 1 |
+| custom_hitmarkers_round_enabled | Rounds damage numbers. | 1 |
 | custom_hitmarkers_hit_duration | How long large hit numbers will linger for. 0 to disable. -1 to use server default. | -1 |
 | custom_hitmarkers_mini_duration | How long mini hit numbers will linger for. 0 to disable. -1 to use server default. | -1 |
 | custom_hitmarkers_hit_sound | Sound used for regular hits. | buttons/lightswitch2.wav |

--- a/lua/custom_hitmarkers/client/cl_toolmenu.lua
+++ b/lua/custom_hitmarkers/client/cl_toolmenu.lua
@@ -211,7 +211,7 @@ hook.Add( "PopulateToolMenu", "CustomHitmarkers_PopulateToolMenu", function()
         entCB = panel:CheckBox( "Enable entity hitmarkers", "custom_hitmarkers_ent_enabled" )
         panel:CheckBox( "Enable hitmarker sounds", "custom_hitmarkers_sound_enabled" )
         panel:CheckBox( "Enable DPS tracker", "custom_hitmarkers_dps_enabled" )
-        panel:CheckBox( "Round up damage numbers", "custom_hitmarkers_round_enabled" )
+        panel:CheckBox( "Round damage numbers", "custom_hitmarkers_round_enabled" )
         panel:CheckBox( "Block zero-damage hits", "custom_hitmarkers_block_zeros" )
 
         local infoPanel = vgui.Create( "DLabel" )


### PR DESCRIPTION
Takes the general code cleanup, network reduction, and initial approach for improving hit number precision for multi-hit damage events from [this PR by Redox](https://github.com/legokidlogan/customizable_hitmarkers/pull/7), but with full execution.

I was planning on simply doing code review on it to fix the nil convar errors it creates and etc, but the PR also didn't actually solve the hit precision problem that sparked its creation, with the full solution ending up getting out of scope for implementing via review.


In theory, and from testing, with `custom_hitmarkers_round_enabled 1`, burst hit numbers should now only be inaccurate by at most +- 1 from final rounding, with rare cases having +-2 from certain weapons triggering two damage events at the same time on occasion (such as the `m9k_m3` when used on players seemingly at random. Not sure if it applies to M9KR as well).